### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Forge is currently based on SD-WebUI 1.10.1 at [this commit](https://github.com/
 
 # News
 
-2024 Oct 28: A new branch `sd35` is contributed by #2183 . I will take a look at quants and sampling and transformer's clip-g vs that clip-g rewrite before merging to main ...
+2024 Oct 28: A new branch `sd35` is contributed by [#2183](https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/2183) . I will take a look at quants and sampling and transformer's clip-g vs that clip-g rewrite before merging to main ...
+
 2024 Sep 7: New sampler `Flux Realistic` is available now! Recommended scheduler is "simple".
 
 # Quick List

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Forge is currently based on SD-WebUI 1.10.1 at [this commit](https://github.com/
 
 # News
 
+2024 Oct 28: A new branch `sd35` is contributed by #2183 . I will take a look at quants and sampling and transformer's clip-g vs that clip-g rewrite before merging to main ...
 2024 Sep 7: New sampler `Flux Realistic` is available now! Recommended scheduler is "simple".
 
 # Quick List

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Forge is currently based on SD-WebUI 1.10.1 at [this commit](https://github.com/
 
 # News
 
+About Gradio 5: will try to upgrade to Gradio 5 at about 2025 March. If failed, then will try again on about 2025 June. relatively positive that we can have Gradio5 before next summer. 
+
 2024 Oct 28: A new branch `sd35` is contributed by [#2183](https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/2183) . I will take a look at quants and sampling and transformer's clip-g vs that clip-g rewrite before merging to main ...
 
 2024 Sep 7: New sampler `Flux Realistic` is available now! Recommended scheduler is "simple".


### PR DESCRIPTION
Cast the tensor to FP32 before using it to workaround the Do not promote FP8 error so FP8 models work.